### PR TITLE
Make L_RECENT_TOPICS title clickable

### DIFF
--- a/styles/all/template/recent_topics_body.html
+++ b/styles/all/template/recent_topics_body.html
@@ -15,12 +15,12 @@
 	<!-- ENDIF -->
 
 	<!-- IF recent_topics.S_FIRST_ROW or not recent_topics.S_TOPIC_TYPE_SWITCH -->
-	<div class="forumbg recent-topics">
+	<div class="forabg recent-topics">
 		<div class="inner">
 		<ul class="topiclist">
 			<li class="header">
 				<dl class="icon">
-					<dt><div class="list-inner">{L_RECENT_TOPICS}</div></dt>
+					<dt><div class="list-inner"><a href="{U_SEARCH_NEW}">{L_RECENT_TOPICS}</a></div></dt>
 					<dd class="posts">{L_REPLIES}</dd>
 					<dd class="views">{L_VIEWS}</dd>
 					<dd class="lastpost"><span>{L_LAST_POST}</span></dd>


### PR DESCRIPTION
Added a clickable link {U_SEARCH_NEW} to L_RECENT_TOPICS title and fixed styling by replacing class "forumbg" by "forabg".
What do you think? :)
